### PR TITLE
implement: failure notify

### DIFF
--- a/check.go
+++ b/check.go
@@ -49,16 +49,17 @@ func (m *Monitor) CheckClusterUpdate() {
 		// initialize
 		if len(m.Tasks) == 0 {
 			m.Tasks = append(m.Tasks, &ECSTask{
-				task,
-				revision,
-				revision,
-				false,
-				v.TaskDefinitionArn,
+				Name:              task,
+				CurrRevision:      revision,
+				NextRevision:      revision,
+				isCurrReivision:   false,
+				TaskDefinitionArn: v.TaskDefinitionArn,
+				FailureCount:      1,
 			})
 		}
 
 		// Check all tasks and set value to struct
-		m.CheckTasksUpdate(task, v.TaskDefinitionArn, revision)
+		m.CheckTasksUpdate(task, v.TaskDefinitionArn, revision, v.LastStatus)
 	}
 
 	// Notification when Revision is updated
@@ -66,7 +67,7 @@ func (m *Monitor) CheckClusterUpdate() {
 }
 
 // CheckTasksUpdate ... Check all tasks and set value to struct
-func (m *Monitor) CheckTasksUpdate(task string, taskDefinitionArn *string, revision int) {
+func (m *Monitor) CheckTasksUpdate(task string, taskDefinitionArn *string, revision int, l *string) {
 	for _, t := range m.Tasks {
 		if t.Name == task {
 			if t.CurrRevision == revision {

--- a/config.go
+++ b/config.go
@@ -6,15 +6,22 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	ColorORANGE = "#F6D64F"
+	ColorRED    = "#F08080"
+)
+
 var (
-	pid = "/tmp/ecs-update-notify.pid"
-	log Logger
+	pid                  = "/tmp/ecs-update-notify.pid"
+	log                  Logger
+	CheckFailureInterval = 20
 )
 
 // Config ... config.toml
 type Config struct {
-	Interval int        `toml:"interval"`
-	Monitors []*Monitor `toml:"monitor"`
+	Interval             int        `toml:"interval"`
+	CheckFailureInterval int        `toml:"check_failure_interval"`
+	Monitors             []*Monitor `toml:"monitor"`
 }
 
 // Monitor ... set from config.toml
@@ -39,11 +46,18 @@ type Logger struct {
 
 // ECSTask ...
 type ECSTask struct {
+	SlackMessage
 	Name              string
 	CurrRevision      int
 	NextRevision      int
 	isCurrReivision   bool
 	TaskDefinitionArn *string
+	FailureCount      int
+}
+
+// ECSFailureTask ...
+type ECSFailureTask struct {
+	SlackMessage
 }
 
 // Slack ... Store Attachment information

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,5 +1,5 @@
 interval = 30
-check_failure_interval = 30 # default: 20
+check_failure_interval = 20 # default: 20
 
 [[monitor]]
 name = "FooCluster"

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,4 +1,5 @@
 interval = 30
+check_failure_interval = 30 # default: 20
 
 [[monitor]]
 name = "FooCluster"

--- a/main.go
+++ b/main.go
@@ -51,6 +51,11 @@ func Start(ctx context.Context, file string, exitCh chan int) {
 		log.sugar.Fatalf("failed to load toml file: %s\n", file)
 	}
 
+	// initialize CheckFailureCount
+	if config.CheckFailureInterval != 0 {
+		CheckFailureInterval = config.CheckFailureInterval
+	}
+
 	// check update
 	go func() {
 		for {


### PR DESCRIPTION
- CheckFailureIntervalをconfigから設定できるようにした（default: 20）
- `example/config.toml` の場合
    - FailureCountは現在のrevisionと、次のrevisionが混在されてるとき、++される
    - その間隔はinterval（30秒）
    - FailureCount % CheckFailureInterval == 0になったら通知
    - なので、30秒  * 20回(CheckFailureInterval) = 600秒 = 10分間隔で通知されるようになる